### PR TITLE
Add a simple Haskell package override as extra dependency example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ For now you can:
 * Select the IDE used
     * For now either ghcide (default) or HIE
 
+### Extra dependencies
+
+In some cases, you might need to use Haskell packages that are not on Nixpkgs.
+This goes beyond the scope of this template.
+However here is some information to achieve that:
+
+0. *WARNING*: You need to know how to write Nix expressions and how Haskell packages are built on Nixpkgs
+1. Look [here](https://github.com/fghibellini/nix-haskell-monorepo/tree/master/extra-deps) for a guide on how to write extra dependencies
+2. Write those extra dependencies in the `./nix/extra-deps.nix` file
+
+Note: don't forget to add those dependencies in your `.cabal` file or else it won't be added.
+
 ## Motivations
 
 I found setting up a Haskell project way more complicated than nearly any modern language.

--- a/nix/extra-deps.nix
+++ b/nix/extra-deps.nix
@@ -1,0 +1,30 @@
+let
+    # Add package function to be called by `buildPackages`
+
+    # Example from https://github.com/fghibellini/nix-haskell-monorepo/tree/master/extra-deps
+    # feel free to remove from project
+    http2-grpc-types = 
+        { mkDerivation, base, binary, bytestring, case-insensitive, fetchgit, hpack, proto-lens, stdenv, zlib }:
+        mkDerivation {
+            pname = "http2-grpc-types";
+            version = "0.3.0.1";
+            src = fetchgit {
+                url = "https://github.com/lucasdicioccio/http2-grpc-types.git";
+                sha256 = "08ni3cl9q3va0sr81dahn17g9wf8fn6srp6nsnvpzrfrp3myfsym";
+                rev = "ea6cd15b9929494e05e0ffb37aedccf915717020";
+                fetchSubmodules = true;
+            };
+            libraryHaskellDepends = [
+                base binary bytestring case-insensitive proto-lens zlib
+            ];
+            libraryToolDepends = [ hpack ];
+            preConfigure = "hpack";
+            homepage = "https://github.com/lucasdicioccio/http2-grpc-types#readme";
+            description = "Types for gRPC over HTTP2 common for client and servers";
+            license = stdenv.lib.licenses.bsd3;
+        };
+in
+    (super: {
+        # Follow this example :
+        http2-grpc-types = super.callPackage http2-grpc-types {};
+    })

--- a/nix/from-cabal.nix
+++ b/nix/from-cabal.nix
@@ -1,7 +1,5 @@
-{ haskellPackages }:
+{ callCabal2nix }:
 let
-  pkgs = import ./nixpkgs.nix;
-
   # From https://github.com/fghibellini/nix-haskell-monorepo/blob/master/monorepo-nix-expressions/monorepo/nix/lib/utils.nix
   findHaskellPackages = root:
     let
@@ -14,7 +12,7 @@ let
   
   found-packages = findHaskellPackages ./../packages;
 
-  call-cabal-package = name: path: haskellPackages.callCabal2nix name path {};
+  call-cabal-package = name: path: callCabal2nix name path {};
   called-packages = builtins.attrValues (builtins.mapAttrs call-cabal-package found-packages);
 
 in

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,7 +1,7 @@
 { usePinnedNixpkgs
-, pinnedNixpkgsRef
-, pinnedNixpkgsUrl
-, pinnedNixpkgsRev
+, pinnedNixpkgsUrl ? "https://github.com/nixos/nixpkgs-channels/"
+, pinnedNixpkgsRef ? "refs/heads/nixos-19.09"
+, pinnedNixpkgsRev ? "107ffbb22ad7920cb3c694dcc1d032a39e003b14"
 }:
 
 # The version of nixpkgs used for this project

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -14,9 +14,9 @@ let
         ref = pinnedNixpkgsRef;
         rev = pinnedNixpkgsRev;
       }
-    ) {};
+    );
   
   # Or the current local
-  current-local = import <nixpkgs> {};
+  current-local = import <nixpkgs>;
 in
   if usePinnedNixpkgs then pinned-nixpkgs else current-local

--- a/packages/hello-world/hello-world.cabal
+++ b/packages/hello-world/hello-world.cabal
@@ -21,6 +21,6 @@ executable hello-world
   main-is:             Main.hs
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.12 && <4.13, lens, http2-grpc-types
+  build-depends:       base
   -- hs-source-dirs:
   default-language:    Haskell2010

--- a/packages/hello-world/hello-world.cabal
+++ b/packages/hello-world/hello-world.cabal
@@ -21,6 +21,6 @@ executable hello-world
   main-is:             Main.hs
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.12 && <4.13, lens
+  build-depends:       base >=4.12 && <4.13, lens, http2-grpc-types
   -- hs-source-dirs:
   default-language:    Haskell2010

--- a/shell.nix
+++ b/shell.nix
@@ -4,12 +4,21 @@ let
   inherit (config) ghc-version use-pinned-nixpkgs pinned-nixpkgs-url pinned-nixpkgs-ref pinned-nixpkgs-rev;
   
   # Nixpkgs
-  pkgs = import ./nix/nixpkgs.nix {
-    usePinnedNixpkgs = use-pinned-nixpkgs;
-    pinnedNixpkgsUrl = pinned-nixpkgs-url;
-    pinnedNixpkgsRef = pinned-nixpkgs-ref;
-    pinnedNixpkgsRev = pinned-nixpkgs-rev;
-  };
+  pkgs = 
+    import ./nix/nixpkgs.nix {
+      usePinnedNixpkgs = use-pinned-nixpkgs;
+      pinnedNixpkgsUrl = pinned-nixpkgs-url;
+      pinnedNixpkgsRef = pinned-nixpkgs-ref;
+      pinnedNixpkgsRev = pinned-nixpkgs-rev;
+    } {
+      config = {
+        packageOverrides = superpkgs: rec {
+          haskellPackages = (superpkgs.lib.attrsets.getAttr ghc-version superpkgs.haskell.packages).override {
+            overrides = self: super: (import ./nix/extra-deps.nix) super;
+          };
+        };
+      };
+    };
   
   # IDEs to chose from
   inherit (config) ide;

--- a/shell.nix
+++ b/shell.nix
@@ -13,6 +13,7 @@ let
     } {
       config = {
         packageOverrides = superpkgs: rec {
+          # Haskell GHC version happens here
           haskellPackages = (superpkgs.lib.attrsets.getAttr ghc-version superpkgs.haskell.packages).override {
             overrides = self: super: (import ./nix/extra-deps.nix) super;
           };
@@ -28,11 +29,11 @@ let
   ghcide = pkgs.lib.attrsets.getAttr ("ghcide-" + ghc-version) (import ./nix/ghcide.nix);
   hie = import ./nix/hie.nix { inherit ghc-version; };
 
-  # Haskell package set with ghcWithPackages changed to always add Hoogle
-  haskellPackages = pkgs.lib.attrsets.getAttr ghc-version pkgs.haskell.packages;
+  # Haskell package set with the right version (see override above)
+  haskellPackages = pkgs.haskellPackages;
 
   # Project loaded with `callCabal2nix`
-  packages-from-cabal = import ./nix/from-cabal.nix { inherit haskellPackages; };
+  packages-from-cabal = import ./nix/from-cabal.nix { inherit (haskellPackages) callCabal2nix; };
 
 in
   # Environment with Haskell development env


### PR DESCRIPTION
Motivation: https://github.com/GuillaumeDesforges/haskell-nix-dev-template/issues/6

Handling this is not in the scope of the project per se, but writing the correct overriding of nixpkgs could be done without much impact on the rest of the template.

Now people only have to edit `./nix/extra-deps.nix`.